### PR TITLE
Feature: Adding Organisation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 ![Alt text](resources/gh/header.png?raw=true "Submoduler")
 
 An app that iterates a list of repositories and updates each of their submodules to the latest commit.
-
-# TODOs
-
-- [x] Run Process for 1 or more repositories using HTTPS and PAT.
-- [ ] Run process for entire organization.
    
 ## Build the Docker Image
 
@@ -52,4 +47,17 @@ interval: 3
   - **init**: if not initialised, init the submodules.
   - **force_reset**: remove any local change and force reset on the submodules.
   - **recursive**: update the children submodules.
+- organization: this key can contain a organization name and configuration for submoduler.
+  e.g.
+  ```yaml
+  organization:
+    test-org-name:
+      to_latest_revision: true
+      init: true
+      force_reset: true
+      recursive: true
+  interval: 3
+  ```
+  When specifying a Organization, all the repos living under it will be pulled and monitored/updated.
+  Right now, only one Submoduler Configuration is supported for all the Org repos, and only 1 repo is supported.
 - **interval**: this defines how often the check is performed on your repository submodules in seconds.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,23 @@
 [[package]]
+name = "certifi"
+version = "2022.9.24"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.1.1"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -51,6 +70,14 @@ python-versions = ">=3.7"
 gitdb = ">=4.0.1,<5"
 
 [[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "loguru"
 version = "0.6.0"
 description = "Python logging made (stupidly) simple"
@@ -74,12 +101,43 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "requests"
+version = "2.28.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<3"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
 name = "smmap"
 version = "5.0.0"
 description = "A pure Python implementation of a sliding window memory map manager"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "urllib3"
+version = "1.26.12"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "win32-setctime"
@@ -95,9 +153,11 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "45f337e8927eb8bc4876fe875e7436b548323508aa18e008b93714463667a2da"
+content-hash = "c34bc7cf551c0fe6593b86383b1ab3b4cc8b1c76afb8e7f3549feaf35dfcf4d7"
 
 [metadata.files]
+certifi = []
+charset-normalizer = []
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -106,6 +166,7 @@ colorama = []
 dacite = []
 gitdb = []
 gitpython = []
+idna = []
 loguru = []
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -142,5 +203,7 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
+requests = []
 smmap = []
+urllib3 = []
 win32-setctime = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ PyYAML = "^6.0"
 loguru = "^0.6.0"
 GitPython = "^3.1.27"
 dacite = "^1.6.0"
+requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/submoduler-organization-example-config.yaml
+++ b/submoduler-organization-example-config.yaml
@@ -1,6 +1,5 @@
-repos:
-  test_repo:
-    url: https://github.com/<your_username>/<repo_name>.git
+organization:
+  test-org-name:
     to_latest_revision: true
     init: true
     force_reset: true

--- a/submoduler/main.py
+++ b/submoduler/main.py
@@ -9,7 +9,7 @@ from submoduler import Submoduler
 
 @click.command
 @click.option('--config_path',
-              help="Path to the configuration file. This supports relative path, e.g.: ../submoduler.yaml.",
+              help="Path to the configuration file. This supports relative path, e.g.: ../submoduler-example-config.yaml.",
               default="/opt/submoduler.yaml")
 @click.option('--user',
               help="Username.",


### PR DESCRIPTION
This change adds Organisation support.

To use it, simply specify an organisation in the config file:

```yaml
organization:
  test-org-name:
    to_latest_revision: true
    init: true
    force_reset: true
    recursive: true
interval: 3
```

The Organisation is retrieved through GitHub API, all its repos gets pulled locally and then monitored/updated.